### PR TITLE
Adds new methods to limit projects and datasets shown

### DIFF
--- a/notes/0.3.1.markdown
+++ b/notes/0.3.1.markdown
@@ -1,0 +1,3 @@
+# 0.3.1
+
+* Adds methods to retrieve datasets and projects limiting the size of the datasets

--- a/notes/0.4.0.markdown
+++ b/notes/0.4.0.markdown
@@ -1,0 +1,3 @@
+# 0.3.1
+
+* Adds methods to retrieve datasets and projects limiting the size of the datasets

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -45,14 +45,16 @@ package object basespace {
         (JsPath \ "Name").format[String] and
         (JsPath \ "DateCreated").format[Date] and
         (JsPath \ "Project" \ "Name").format[String] and
-        (JsPath \ "DatasetType" \ "Name").format[String]
+        (JsPath \ "DatasetType" \ "Id").format[String] and
+        (JsPath \ "TotalSize").format[Long]
     )(Dataset.apply, unlift(Dataset.unapply))
 
     implicit val projectFormat: Format[Project] = (
       (JsPath \ "Id").format[ID] and
         (JsPath \ "Name").format[String] and
         (JsPath \ "Description").format[String] and
-        (JsPath \ "DateCreated").format[Date]
+        (JsPath \ "DateCreated").format[Date] and
+        (JsPath \ "ImportableDatasets").formatNullable[Long]
     )(Project.apply, unlift(Project.unapply))
   }
 }
@@ -85,13 +87,15 @@ package basespace {
       val name: String,
       val date: Date,
       val projectName: String,
-      val datasetType: String
+      val datasetType: String,
+      val size: Long
   )
 
   final case class Project(
       val id: ID,
       val name: String,
       val description: String,
-      val date: Date
+      val date: Date,
+      val importableDatasets: Option[Long]
   )
 }


### PR DESCRIPTION
This release includes methods that return only datasets which are below a given size or have an specific type (a.k.a. we intend to import only FASTQ files)